### PR TITLE
Fixed cinder deployment script

### DIFF
--- a/jobs/deploy_cinder_windows_vm.sh
+++ b/jobs/deploy_cinder_windows_vm.sh
@@ -1,3 +1,18 @@
+join_cinder(){
+    set +e
+    WIN_USER=$1
+    WIN_PASS=$2
+    WIN_IP=$3
+
+    PARAMS="$WIN_IP $WIN_USER $WIN_PASS"
+    set -e
+    run_ps_cmd_with_retry $PARAMS "\$env:Path += ';C:\Python27;C:\Python27\Scripts;C:\OpenSSL-Win32\bin;C:\Program Files (x86)\Git\cmd;C:\MinGW\mingw32\bin;C:\MinGW\msys\1.0\bin;C:\MinGW\bin;C:\qemu-img'; setx PATH \$env:Path "
+    run_ps_cmd_with_retry $PARAMS "git clone https://github.com/cloudbase/cinder-ci C:\cinder-ci"
+    run_ps_cmd_with_retry $PARAMS "cd C:\cinder-ci; git checkout cinder"
+    run_ps_cmd_with_retry $PARAMS "bash C:\cinder-ci\windows\scripts\gerrit-git-prep.sh --zuul-site $ZUUL_SITE --gerrit-site $ZUUL_SITE --zuul-ref $ZUUL_REF --zuul-change $ZUUL_CHANGE --zuul-project cinder"
+    run_ps_cmd_with_retry $PARAMS "C:\cinder-ci\windows\scripts\create-environment.ps1 -devstackIP $FIXED_IP -branchName $ZUUL_BRANCH -buildFor $ZUUL_PROJECT"
+}
+
 export CINDER_VM_NAME="cinder-windows-$UUID"
 echo CINDER_VM_NAME=$CINDER_VM_NAME >> devstack_params_$ZUUL_CHANGE.txt
 

--- a/jobs/smb3_windows/local-conf-extra
+++ b/jobs/smb3_windows/local-conf-extra
@@ -4,3 +4,8 @@ TEMPEST_VOLUME_VENDOR="Open Source"
 TEMPEST_STORAGE_PROTOCOL=smbfs
 
 disable_service c-vol
+
+[[post-config|$NOVA_CONF]]
+[libvirt]
+# libvirt-qemu uid, gid
+smbfs_mount_options='-o uid=107,gid=105'


### PR DESCRIPTION
Adds back the join_cinder function. Also, the libvirt uid and gid are set as smb mount options on Nova.
