### PR TITLE
Forced oslo.log==1.1.0 on windows

### DIFF
--- a/windows/scripts/create-environment.ps1
+++ b/windows/scripts/create-environment.ps1
@@ -35,6 +35,7 @@ Write-Host "Ensure Python folder is up to date"
 cmd /c cd \ `&`& C:\MinGW\msys\1.0\bin\tar.exe xvzf $archivePath
 Remove-Item -Force -Recurse "c:\$archivePath"
 pip install -U pip
+pip install oslo.log==1.1.0
 pip install wmi
 pip install cffi==1.0.1
 pip install virtualenv


### PR DESCRIPTION
oslo.log==1.2.0 (latest on 27.05.2015) has issues because it tries to
import syslog on windows

Signed-off-by: Victor Laza vlaza@cloudbasesolutions.com
