### PR TITLE
Forced pbr to 1.2.0

### DIFF
--- a/windows/scripts/create-environment.ps1
+++ b/windows/scripts/create-environment.ps1
@@ -39,6 +39,7 @@ pip install oslo.log==1.1.0
 pip install wmi
 pip install cffi==1.0.1
 pip install virtualenv
+pip install pbr==1.2.0
 #pip install -U setuptools
 pip install -U distribute
 


### PR DESCRIPTION
This cap is needed because cinder fails to install with pbr==1.3.0
