### PR TITLE
Cap to pbr 1.2.0 on Windows

### DIFF
--- a/windows/scripts/create-environment.ps1
+++ b/windows/scripts/create-environment.ps1
@@ -38,6 +38,7 @@ easy_install -U pip
 pip install oslo.log==1.1.0
 pip install wmi
 pip install cffi==1.0.1
+pip install pbr==1.2.0
 pip install virtualenv
 pip install -U setuptools
 pip install -U distribute


### PR DESCRIPTION
Needed because cinder does not build on windows with latest pbr
