### PR TITLE
New cleaner, lighter and up-to-date glance image

### DIFF
--- a/devstack_vm/bin/run_devstack.sh
+++ b/devstack_vm/bin/run_devstack.sh
@@ -17,7 +17,6 @@ sudo easy_install -U pip
 #Update six to latest version
 sudo pip install -U six
 sudo pip install -U kombu
-sudo pip uninstall PasteDeploy -y
 
 #Running an extra apt-get update
 sudo apt-get update --assume-yes

--- a/jobs/deploy_devstack_vm.sh
+++ b/jobs/deploy_devstack_vm.sh
@@ -43,7 +43,7 @@ then
     echo NET_ID=$NET_ID
 
     echo "Deploying devstack $NAME"
-    nova boot --availability-zone cinder --flavor cinder.linux --image devstack-61 --key-name default --security-groups devstack --nic net-id="$NET_ID" "$NAME" --poll
+    nova boot --availability-zone cinder --flavor cinder.linux --image devstack-62v2 --key-name default --security-groups devstack --nic net-id="$NET_ID" "$NAME" --poll
 
     if [ $? -ne 0 ]
     then


### PR DESCRIPTION
- newest kernel .62
- PasteDeploy uninstalled
- latest pip 7.1.0
- size reduced from 3.4 to 2.0 GB
- devstack repo up-to-date
- core packages updated
