### PR TITLE
Moved tempest iniset to run_all_tests

### DIFF
--- a/devstack_vm/bin/run-all-tests.sh
+++ b/devstack_vm/bin/run-all-tests.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
+source /home/ubuntu/devstack/functions
+TEMPEST_CONFIG=/opt/stack/tempest/etc/tempest.conf
+
+#iniset $TEMPEST_CONFIG compute volume_device_name "sdb"
+iniset $TEMPEST_CONFIG compute-feature-enabled rdp_console true
+iniset $TEMPEST_CONFIG compute-feature-enabled block_migrate_cinder_iscsi False
+
+iniset $TEMPEST_CONFIG scenario img_dir "/home/ubuntu/devstack/files/images"
+iniset $TEMPEST_CONFIG scenario img_file "cirros-0.3.3-x86_64.img"
+iniset $TEMPEST_CONFIG scenario img_disk_format qcow2
+
+IMAGE_REF=`iniget $TEMPEST_CONFIG compute image_ref`
+iniset $TEMPEST_CONFIG compute image_ref_alt $IMAGE_REF
+
+iniset $TEMPEST_CONFIG compute build_timeout 300
+iniset $TEMPEST_CONFIG orchestration build_timeout 120
+iniset $TEMPEST_CONFIG volume build_timeout 300
+iniset $TEMPEST_CONFIG boto build_timeout 300
+
+iniset $TEMPEST_CONFIG compute ssh_timeout 180
+iniset $TEMPEST_CONFIG compute allow_tenant_isolation True
 
 #cinder-specific job type parameter 
 job_type=$1

--- a/devstack_vm/devstack/local.sh
+++ b/devstack_vm/devstack/local.sh
@@ -14,27 +14,6 @@ nova flavor-create m1.micro 84 128 2 1
 subnet_id=`neutron net-show private | grep subnets | awk '{print $4}'`
 neutron subnet-update $subnet_id --dns_nameservers list=true 8.8.8.8 8.8.4.4
 
-TEMPEST_CONFIG=/opt/stack/tempest/etc/tempest.conf
-
-#iniset $TEMPEST_CONFIG compute volume_device_name "sdb"
-iniset $TEMPEST_CONFIG compute-feature-enabled rdp_console true
-iniset $TEMPEST_CONFIG compute-feature-enabled block_migrate_cinder_iscsi False
-
-iniset $TEMPEST_CONFIG scenario img_dir "/home/ubuntu/devstack/files/images"
-iniset $TEMPEST_CONFIG scenario img_file "cirros-0.3.3-x86_64.img"
-iniset $TEMPEST_CONFIG scenario img_disk_format qcow2
-
-IMAGE_REF=`iniget $TEMPEST_CONFIG compute image_ref`
-iniset $TEMPEST_CONFIG compute image_ref_alt $IMAGE_REF
-
-iniset $TEMPEST_CONFIG compute build_timeout 300
-iniset $TEMPEST_CONFIG orchestration build_timeout 120
-iniset $TEMPEST_CONFIG volume build_timeout 300
-iniset $TEMPEST_CONFIG boto build_timeout 300
-
-iniset $TEMPEST_CONFIG compute ssh_timeout 180
-iniset $TEMPEST_CONFIG compute allow_tenant_isolation True
-
 # Disable STP on bridge
 # ovs-vsctl set bridge br-eth1 stp_enable=true
 


### PR DESCRIPTION
They were previously placed in local.sh, but it seems that stack.sh
overwrites them.