### PR TITLE
Added cherry-pick for patch "refs/changes/56/455256/1" on cinder and …

### DIFF
--- a/devstack_vm/bin/excluded-tests-iscsi.txt
+++ b/devstack_vm/bin/excluded-tests-iscsi.txt
@@ -21,4 +21,3 @@ tempest.api.volume.admin.test_volume_types.VolumeTypesV2Test.test_volume_type_en
 tempest.api.volume.admin.test_volume_types.VolumeTypesV2Test.test_volume_type_list
 
 tempest.api.volume.admin.test_snapshot_manage.SnapshotManageAdminTest
-tempest.api.volume.test_volume_delete_cascade.VolumesDeleteCascade

--- a/devstack_vm/bin/excluded-tests-smb3_windows.txt
+++ b/devstack_vm/bin/excluded-tests-smb3_windows.txt
@@ -23,4 +23,3 @@ tempest.api.volume.test_volumes_snapshots.VolumesSnapshotTestJSON.test_snapshot_
 tempest.api.volume.test_volumes_snapshots.VolumesSnapshotTestJSON.test_snapshot_delete_with_volume_in_use
 
 tempest.api.volume.admin.test_snapshot_manage
-tempest.api.volume.test_volume_delete_cascade.VolumesDeleteCascade

--- a/windows/scripts/install_cinder.ps1
+++ b/windows/scripts/install_cinder.ps1
@@ -77,6 +77,9 @@ if ($branchName.ToLower() -eq "master" -or $branchName.ToLower() -eq "stable/new
         
         git fetch git://git.openstack.org/openstack/cinder refs/changes/19/426719/3
         cherry_pick FETCH_HEAD
+
+        git fetch git://git.openstack.org/openstack/cinder refs/changes/56/455256/1
+        cherry_pick FETCH_HEAD
         popd
     }
 }


### PR DESCRIPTION
…removed "tempest.api.volume.test_volume_delete_cascade.VolumesDeleteCascade" from the excluded tempest list